### PR TITLE
Fix vagrant provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ $post_up_message = "** Your Vagrant box is ready to use! \o/ **
 Log in (with 'vagrant ssh') and follow the instructions."
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "ubuntu/xenial64"
 
   # Enable NFS access to the disk
   config.vm.synced_folder "", "/vagrant", nfs: true

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,8 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
-$post_up_message = "** Your Vagrant box is ready to use! \o/ **
-Log in (with 'vagrant ssh') and follow the instructions."
+$post_up_message = '** Your Vagrant box is ready to use! \o/ **
+Log in (with `vagrant ssh`) and follow the instructions.'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/xenial64"

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -14,13 +14,6 @@ sudo update-locale LANG=en_GB.utf8
 wget -qO - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | sudo apt-key add -
 echo 'deb http://packages.elasticsearch.org/elasticsearch/1.4/debian stable main' | sudo tee /etc/apt/sources.list.d/elasticsearch.list
 
-# Instructions from: http://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
-
-# Instructions from: https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager
-wget -qO - https://deb.nodesource.com/setup | sudo bash -
-
 # Install the packages we need
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y
@@ -29,7 +22,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   python-dev python-pip python-virtualenv \
   rabbitmq-server \
   openjdk-7-jre elasticsearch \
-  mongodb-org nodejs gettext
+  gettext
 
 # Set virtualenv directory and create it if needed.
 virtualenv_dir="/home/vagrant/writeit-virtualenv"

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -38,7 +38,10 @@ cd /vagrant
 # Make sure message files for other languages are compiled:
 "$virtualenv_dir/bin/python" /vagrant/manage.py compilemessages
 
+motd_file="/etc/update-motd.d/99-writeit-instructions"
+
 # Set shell login message
+echo '#!/bin/sh
 echo "-------------------------------------------------------
 Welcome to the WriteIt vagrant machine
 
@@ -59,8 +62,9 @@ Run celery beat with:
 Run the tests with:
   ./manage.py test nuntium contactos mailit
 
--------------------------------------------------------
-" | sudo tee /etc/motd.tail > /dev/null
+-------------------------------------------------------"
+' | sudo tee "$motd_file" > /dev/null
+sudo chmod +x "$motd_file"
 
 # Add cd /vagrant to ~/.bashrc
 grep -qG "cd /vagrant" "$HOME/.bashrc" || echo "cd /vagrant" >> "$HOME/.bashrc"

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -7,9 +7,6 @@ pwd
 now=$(date +"%T")
 echo "$now Running provision.sh"
 
-# Use the en_GB.utf8 locale
-sudo update-locale LANG=en_GB.utf8
-
 # Instructions from: https://www.elastic.co/guide/en/elasticsearch/reference/1.4/setup-repositories.html
 wget -qO - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | sudo apt-key add -
 echo 'deb http://packages.elasticsearch.org/elasticsearch/1.4/debian stable main' | sudo tee /etc/apt/sources.list.d/elasticsearch.list
@@ -20,11 +17,11 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   git libffi-dev libssl-dev build-essential yui-compressor sqlite3 postfix \
   python-dev python-pip python-virtualenv \
   rabbitmq-server \
-  openjdk-7-jre elasticsearch \
+  openjdk-8-jre elasticsearch \
   gettext
 
 # Set virtualenv directory and create it if needed.
-virtualenv_dir="/home/vagrant/writeit-virtualenv"
+virtualenv_dir="/home/ubuntu/writeit-virtualenv"
 [[ -d "$virtualenv_dir" ]] || virtualenv "$virtualenv_dir"
 
 # Install the python requirements

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -16,7 +16,6 @@ echo 'deb http://packages.elasticsearch.org/elasticsearch/1.4/debian stable main
 
 # Install the packages we need
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
   git libffi-dev libssl-dev build-essential yui-compressor sqlite3 postfix \
   python-dev python-pip python-virtualenv \


### PR DESCRIPTION
This makes a few changes so that `vagrant up` works once again.

- Switch to Ubuntu Xenial 16.04 (the latest LTS)
- Remove mongodb and nodejs since we no longer need those now we've switch to django-popolo
- Change how the motd banner with instructions is installed to use update-motd.d
- Couple of other minor tweaks and updates, see diff