### PR TITLE
Allow filtering messages in API by Popolo URI

### DIFF
--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -68,3 +68,9 @@ This is how [PlanningAlerts](https://github.com/openaustralia/planningalerts/) i
 A GET request is all that's needed to get a message and all its replies as JSON, e.g.
 
     http://writeit.ciudadanointeligente.org/api/v1/message/1234/?format=json&username=henare&api_key=ABC123
+
+### Fetching messages sent to a specific person
+
+To get a list of messages that were sent to a specific person you can provide a `?person__popolo_uri` GET parameter. The value of this parameter should be the URL encoded Popolo URI for the person. The Popolo URI is in the same format as the one used when creating new messages, e.g.
+
+    http://writeit.ciudadanointeligente.org/api/v1/instance/1/messages/?format=json&username=henare&api_key=ABC123&person__popolo_uri=https%3A%2F%2Feverypolitician-writeinpublic.herokuapp.com%2FAustralia%2FSenate%2Fpersons%2Fperson%2Fb6b705a5-0355-4f1c-8951-273aed19156d

--- a/nuntium/api.py
+++ b/nuntium/api.py
@@ -206,6 +206,14 @@ class MessageResource(ModelResource):
                 )
             except ObjectDoesNotExist:
                 raise Http404("PopoloPerson does not exist")
+        if 'person__popolo_uri' in filters:
+            try:
+                person = queryset.get(
+                    identifiers__scheme='popolo_uri',
+                    identifiers__identifier=filters['person__popolo_uri'],
+                )
+            except ObjectDoesNotExist:
+                raise Http404("PopoloPerson does not exist")
         if person:
             result['person'] = person
         return result


### PR DESCRIPTION
This adds a `?person__popolo_uri` filter to the API which works in a similar way to the existing `person__popit_id` filter, but looks at the identifiers with a `popolo_uri` scheme.

The hardest part of this change was writing the test for it. I'm still not totally happy with how it works, but it at least works as a regression test for now. Suggestions welcome!

Fixes https://github.com/mysociety/alpaca/issues/70